### PR TITLE
Release 43.5.0+0.4.3.5

### DIFF
--- a/libtor/Cargo.toml
+++ b/libtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libtor"
-version = "42.7.1+0.4.2.7"
+version = "43.5.1+0.4.3.5"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/MagicalBitcoin/libtor"
@@ -11,6 +11,6 @@ keywords = ["tor", "daemon"]
 readme = "README.md"
 
 [dependencies]
-libtor-sys = "42.7.1"
+libtor-sys = "43.5.1"
 libtor-derive = "0.1"
 log = "^0.4"


### PR DESCRIPTION
Upgrade Tor to 0.4.3.5. Includes changes from MagicalBitcoin/libtor-sys#4