### PR TITLE
Expose vendored-openssl from libtor-sys

### DIFF
--- a/libtor/Cargo.toml
+++ b/libtor/Cargo.toml
@@ -14,3 +14,6 @@ readme = "README.md"
 libtor-sys = "44.5.1"
 libtor-derive = "0.1"
 log = "^0.4"
+
+[features]
+vendored-openssl = ["libtor-sys/vendored-openssl"]


### PR DESCRIPTION
Depends on MagicalBitcoin/libtor-sys#6