### PR TITLE
Fix generating unparsable log level line

### DIFF
--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -130,7 +130,7 @@ fn log_expand(flag: &TorFlag) -> Vec<String> {
         .collect::<Vec<String>>()
         .join(" ");
     let dest_str = dest
-        .map(|d| format!(" {:?}", d).to_lowercase())
+        .map(|d| format!(" {}", d).to_lowercase())
         .unwrap_or_default();
 
     vec!["Log".into(), format!("{}{}", levels_str, dest_str)]
@@ -228,6 +228,7 @@ pub enum TorFlag {
     #[expand_to(test = (LogLevel::Notice) => "Log \"notice\"")]
     Log(LogLevel),
     #[expand_to(with = "log_expand")]
+    #[expand_to(test = (LogLevel::Notice, LogDestination::File("/dev/null".into())) => "Log \"notice file /dev/null\"")]
     #[expand_to(test = (LogLevel::Notice, LogDestination::Stdout) => "Log \"notice stdout\"")]
     LogTo(LogLevel, LogDestination),
     #[expand_to(with = "log_expand")]

--- a/libtor/src/log.rs
+++ b/libtor/src/log.rs
@@ -19,6 +19,14 @@ pub enum LogDestination {
     #[cfg(target_os = "android")]
     Android,
 }
+impl std::fmt::Display for LogDestination {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LogDestination::File(path) => write!(f, "file {}", path),
+            _ => write!(f, "{:?}", self),
+        }
+    }
+}
 
 /// Log domain, for fine grained control
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Calling`.flag(TorFlag::LogTo(LogLevel::Warn, LogDestination::File("/dev/null".into())))` before resulted in following error:
`Dec 17 07:00:08.609 [warn] Bad syntax on file Log option 'Log warn file("/dev/null")'`

The line should look like this: `Log warn file /dev/null`. I implemented fmt for LogDestination to solve this, as using the Debug formatting caused this issue.
