### PR TITLE
Make utils public so we can access DisplayOption

### DIFF
--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -29,7 +29,7 @@ use std::thread::{self, JoinHandle};
 use log_crate::{debug, error, info, trace};
 
 #[macro_use]
-mod utils;
+pub mod utils;
 /// Hidden services related flags
 pub mod hs;
 /// Log related flags


### PR DESCRIPTION
This is probably ugly/hacky but it's a quick fix for https://github.com/MagicalBitcoin/libtor/issues/7