### PR TITLE
Implement TorFlag::Log() and TorFlag::Hush()

### DIFF
--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -296,6 +296,13 @@ pub enum TorFlag {
     /// Custom argument, expanded as `<first_word> "<second_word> <third_word> ..."`
     #[expand_to("{}")]
     Custom(String),
+
+    /// Don't log anything to the console
+    #[expand_to("--quiet")]
+    Quiet(),
+    /// Only log warnings and errors to the console
+    #[expand_to("--hush")]
+    Hush(),
 }
 
 /// Error enum


### PR DESCRIPTION
These two flags allow suppressing log to stdout. 

Description from https://manpages.debian.org/jessie/tor/torrc.5
```
--quiet|--hush
Override the default console log. By default, Tor starts out logging messages at level "notice"
 and higher to the console. It stops doing so after it parses its configuration, if the configuration
 tells it to log anywhere else. You can override this behavior with the --hush option, which tells
 Tor to only send warnings and errors to the console, or with the --quiet option, which tells Tor 
not to log to the console at all.
```