### PR TITLE
feat: include serde support via feature flag

### DIFF
--- a/libtor/Cargo.toml
+++ b/libtor/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 libtor-sys = "46.6"
 libtor-derive = "^0.1.2"
 log = "^0.4"
+serde = { version = "1.0.130", features = ["derive"], optional = true }
 
 [features]
 vendored-openssl = ["libtor-sys/vendored-openssl"]

--- a/libtor/src/hs.rs
+++ b/libtor/src/hs.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Hidden service version
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HiddenServiceVersion {
-    #[deprecated(
-        note = "Please migrate to V3 hidden services",
-    )]
+    #[deprecated(note = "Please migrate to V3 hidden services")]
     V2 = 2,
     V3 = 3,
 }
@@ -16,6 +18,7 @@ impl std::fmt::Display for HiddenServiceVersion {
 
 /// Hidden service authorization type for authorized clients
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HiddenServiceAuthType {
     Basic,
     Stealth,

--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -22,6 +22,12 @@ extern crate libtor_derive;
 extern crate log as log_crate;
 extern crate tor_sys;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::ffi::CString;
 use std::thread::{self, JoinHandle};
 
@@ -58,6 +64,7 @@ trait Expand: std::fmt::Debug {
 
 /// Enum that represents the size unit both in bytes and bits
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SizeUnit {
     Bytes,
     KBytes,
@@ -75,6 +82,7 @@ display_like_debug!(SizeUnit);
 
 /// Enum that represents a bool, rendered as `1` for true/enabled and `0` for false/disabled
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TorBool {
     True,
     False,
@@ -140,6 +148,7 @@ fn log_expand(flag: &TorFlag) -> Vec<String> {
 ///
 /// It can also represent Unix sockets on platforms that support them.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TorAddress {
     /// Shorthand to only encode the port
     Port(u16),
@@ -170,6 +179,7 @@ impl std::fmt::Display for TorAddress {
 /// targeted more to a client-like usage. Arbitrary flags can still be added using the
 /// `TorFlag::Custom(String)` variant.
 #[derive(Debug, Clone, Expand)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TorFlag {
     #[expand_to("-f {}")]
     #[expand_to(test = ("filename".into()) => "-f \"filename\"")]
@@ -307,6 +317,7 @@ pub enum TorFlag {
 
 /// Error enum
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     NotRunning,
 }
@@ -326,6 +337,7 @@ impl std::error::Error for Error {}
 /// Offers the ability to set multiple flags and then start the daemon either in the current
 /// thread, or in a new one
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tor {
     flags: Vec<TorFlag>,
 }

--- a/libtor/src/log.rs
+++ b/libtor/src/log.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Log level
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LogLevel {
     Debug,
     Info,
@@ -10,6 +14,7 @@ pub enum LogLevel {
 
 /// Log destination
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LogDestination {
     Stdout,
     Stderr,
@@ -30,6 +35,7 @@ impl std::fmt::Display for LogDestination {
 
 /// Log domain, for fine grained control
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LogDomain {
     General,
     Crypto,

--- a/libtor/src/ports.rs
+++ b/libtor/src/ports.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Flags to change the behavior of the control port
 ///
 /// Currently, all of the possible flags are only available on Unix systems since they only
 /// apply to the "unix" type of ControlPort
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ControlPortFlag {
     #[cfg(target_family = "unix")]
     GroupWritable,
@@ -14,6 +18,7 @@ pub enum ControlPortFlag {
 
 /// Flags to change the behavior of the socks port
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SocksPortFlag {
     NoIPv4Traffic,
     IPv6Traffic,
@@ -35,6 +40,7 @@ pub enum SocksPortFlag {
 
 /// Flags to change the isolation of clients connected to the control port
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SocksPortIsolationFlag {
     IsolateClientAddr,
     IsolateSOCKSAuth,

--- a/libtor/src/utils.rs
+++ b/libtor/src/utils.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 macro_rules! display_like_debug {
     ($type:ty) => {
         impl std::fmt::Display for $type {
@@ -14,6 +17,7 @@ pub trait Joiner: std::fmt::Debug + std::clone::Clone {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CommaJoiner {}
 impl Joiner for CommaJoiner {
     fn joiner(&self) -> String {
@@ -26,6 +30,7 @@ impl Joiner for CommaJoiner {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpaceJoiner {}
 impl Joiner for SpaceJoiner {
     fn joiner(&self) -> String {
@@ -38,6 +43,7 @@ impl Joiner for SpaceJoiner {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DisplayVec<T: std::fmt::Debug + std::fmt::Display, J: Joiner> {
     vec: Vec<T>,
     joiner: J,
@@ -65,6 +71,7 @@ impl<T: std::fmt::Debug + std::fmt::Display, J: Joiner> From<Vec<T>> for Display
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DisplayOption<T: std::fmt::Debug + std::fmt::Display> {
     option: Option<T>,
 }


### PR DESCRIPTION
This would add the capability to use serde capabilities within and outside this crate.

One application for such a thing is using [mitosis](https://docs.rs/mitosis/0.1.1/mitosis/) to run different processes and therefor multiple instances or tor, eliminating the need for mutexes to check how many and which instances are running.

It's enabled as a feature flag, so no worries it doesn't mess with any existing setup.

Cheers :beers:

I'm new to rust, so just hit me up if something isn't how it should be

@afilini @danielabrozzoni 