### PR TITLE
Added generate_hashed_password

### DIFF
--- a/libtor/Cargo.toml
+++ b/libtor/Cargo.toml
@@ -15,6 +15,8 @@ libtor-sys = "46.6"
 libtor-derive = "^0.1.2"
 log = "^0.4"
 serde = { version = "1.0.130", features = ["derive"], optional = true }
+rand = "0.8"
+sha1 = "0.6"
 
 [features]
 vendored-openssl = ["libtor-sys/vendored-openssl"]

--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -403,15 +403,15 @@ pub fn generate_hashed_password(secret: &str) -> String {
     // https://gist.github.com/s4w3d0ff/9d65ec5866d78842547183601b2fa4d5
     // s4w3d0ff and jamesacampbell, Thank you!
 
+    let c: usize = 96;
+    const EXPBIAS: usize = 6;
+    let mut count = (16_usize + (c & 15_usize)) << ((c >> 4_usize) + EXPBIAS);
+    let mut d = sha1::Sha1::new();
+
     let slen = 8 + (secret.as_bytes().len());
     let mut tmp = Vec::with_capacity(slen);
     tmp.extend_from_slice(&rand::rngs::OsRng.gen::<u64>().to_ne_bytes());
     tmp.extend_from_slice(secret.as_bytes());
-    let c: usize = 96;
-
-    const EXPBIAS: usize = 6;
-    let mut count = (16_usize + (c & 15_usize)) << ((c >> 4_usize) + EXPBIAS);
-    let mut d = sha1::Sha1::new();
 
     while count != 0 {
         if count > slen {
@@ -422,7 +422,7 @@ pub fn generate_hashed_password(secret: &str) -> String {
             break;
         }
     }
-    let hashed = d.digest().to_string();
+    let hashed = d.digest().to_string().to_uppercase();
     let tmp = tmp[..8]
         .iter()
         .map(|n| format!("{:X}", n))

--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -397,7 +397,7 @@ impl Tor {
 }
 
 /// Generate a hashed password to use HashedControlPassword
-pub fn hashed_password_generator(secret: &str) -> String {
+pub fn generate_hashed_password(secret: &str) -> String {
     // This code is rewrite of
     // https://gist.github.com/s4w3d0ff/9d65ec5866d78842547183601b2fa4d5
     // s4w3d0ff and jamesacampbell, Thank you!

--- a/libtor/src/lib.rs
+++ b/libtor/src/lib.rs
@@ -422,13 +422,13 @@ pub fn generate_hashed_password(secret: &str) -> String {
             break;
         }
     }
-    let hashed = d.digest().to_string().to_uppercase();
+    let hashed = d.digest().to_string();
     let tmp = tmp[..8]
         .iter()
-        .map(|n| format!("{:X}", n))
+        .map(|n| format!("{:x}", n))
         .collect::<String>();
 
-    format!("16:{}{:X}{}", tmp, c as u8, hashed)
+    format!("16:{}{:x}{}", tmp, c as u8, hashed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Without generate_hashed_password, you need tor binary to get the hashed password for HashedControlPassword.
By merging this, you can get the hashed password without using the Tor binary.

This is the rewrite of [this gist](https://gist.github.com/s4w3d0ff/9d65ec5866d78842547183601b2fa4d5)